### PR TITLE
Fix dropout layer comment typo

### DIFF
--- a/neural_network_m.py
+++ b/neural_network_m.py
@@ -88,7 +88,7 @@ class Soft_max:
 
 
 
-#Dropot Layer
+# Dropout Layer
 class Dropout:
     """
     Dropout Layer: Randomly sets a fraction of inputs to 0 during training to prevent overfitting.


### PR DESCRIPTION
## Summary
- correct typo in comment above `Dropout` class

## Testing
- `python -m py_compile neural_network_m.py`

------
https://chatgpt.com/codex/tasks/task_e_6840a31fa40483248cd3a8664fb4c72f